### PR TITLE
Create .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# linguist overrides
+*.sql linguist-language=TSQL


### PR DESCRIPTION
This will enable detection of sql files as t-sql. Eg, fixes this:

![image](https://user-images.githubusercontent.com/441085/68515469-07843c00-024f-11ea-9e93-c852124c6c39.png)
