### PR TITLE
Fix sort order case-sensitivity issue

### DIFF
--- a/who_is_active.sql
+++ b/who_is_active.sql
@@ -1100,8 +1100,8 @@ BEGIN;
 		SELECT
 			x.column_name +
 				CASE
-					WHEN tokens.next_chunk LIKE '%asc%' THEN ' ASC'
-					WHEN tokens.next_chunk LIKE '%desc%' THEN ' DESC'
+					WHEN LOWER(tokens.next_chunk) LIKE '%asc%' THEN ' ASC'
+					WHEN LOWER(tokens.next_chunk) LIKE '%desc%' THEN ' DESC'
 					ELSE ''
 				END AS column_name,
 			ROW_NUMBER() OVER


### PR DESCRIPTION
fixed case sensitivity issue with @sort_order parameter.

there are likely a bunch of other places where this could occur, e.g.
![image](https://user-images.githubusercontent.com/2136037/94999639-c55f9980-0588-11eb-960a-60ef1921eac2.png)

if a user passes in `DD HH:MM:SS.MSS` or something. But let's start small.