### PR TITLE
Added Memory DMV to handle memory requests, and grants 

### DIFF
--- a/who_is_active.sql
+++ b/who_is_active.sql
@@ -2072,7 +2072,7 @@ BEGIN;
 									blk.session_id = 0
 									AND @blocker = 0
 								)
-								LEFT JOIN 
+								INNER JOIN 
 									sys.dm_exec_query_memory_grants mg 
 								ON 
 									sp2.spid = mg.session_id


### PR DESCRIPTION
I added requested and granted memory from sys.dm_exec_query_memory_grants DMV replacing what was there from sys.sysprocesses. This fundamentally changes how we are counting memory and the DMV we are relying on for our memory counters.  Instead of counting pages and calculating our extents to come up with our kb usage; I am just exposing the pre-calculated requested, and granted memory counters measured in kb. This lets us to see exactly who is requesting how much memory,  further allowing us to focus on the problem queries causing the Resource Semaphore condition to occur. 