### PR TITLE
[FIX] Remove last_request_end_time predicate

### DIFF
--- a/who_is_active.sql
+++ b/who_is_active.sql
@@ -1825,11 +1825,7 @@ BEGIN;
 							s.is_user_process = 0
 							AND sp.is_user_process = 0
 						)
-						OR
-						(
-							r.start_time = s.last_request_start_time
-							AND s.last_request_end_time <= sp.last_request_end_time
-						)
+						OR r.start_time = s.last_request_start_time
 					) ';
 
 		SET @sql =


### PR DESCRIPTION
I think this will fix various bugs. On the flip side, I have no idea what problems it will cause. This predicate was in place for about a decade and I can't remember why I put it in place.