### PR TITLE
getting rid of SP_SERVER_DIAGNOSTICS_SLEEP

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -2265,7 +2265,7 @@ BEGIN;
                             END +
                             CASE
                                 WHEN @show_system_spids = 0 THEN
-                                    'AND sp0.hostprocess > '''' AND NULLIF(sp0.wait_type, '''') NOT IN (N''SP_SERVER_DIAGNOSTICS_SLEEP'')
+                                    'AND sp0.hostprocess > '''' AND COALESCE(sp0.wait_type, '''') NOT IN (N''SP_SERVER_DIAGNOSTICS_SLEEP'')
                                     '
                                 ELSE
                                     ''

--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -2265,7 +2265,7 @@ BEGIN;
                             END +
                             CASE
                                 WHEN @show_system_spids = 0 THEN
-                                    'AND sp0.hostprocess > ''''
+                                    'AND sp0.hostprocess > '''' AND NULLIF(sp0.wait_type, '''') NOT IN (N''SP_SERVER_DIAGNOSTICS_SLEEP'')
                                     '
                                 ELSE
                                     ''


### PR DESCRIPTION
Was tired of having SP_SERVER_DIAGNOSTICS_SLEEP session in the result (AlwaysOn heartbeat). Added it in the filter for `@show_system_spids = 0`

Sorry for other stuff in the diff, don't know what happened with carriage returns?