### PR TITLE
Adding handling for errors in Azure SQL DB

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -3082,7 +3082,10 @@ BEGIN;
                                 OR @find_block_leaders = 1
                             ) THEN
                                 'sp.wait_type COLLATE Latin1_General_Bin2 AS wait_type,
-                                sp.wait_resource COLLATE Latin1_General_Bin2 AS resource_description,
+                                CASE
+                                    WHEN CHARINDEX(N''('',sp.wait_resource) > 0 THEN TRIM(LEFT(sp.wait_resource,CHARINDEX(N''('',sp.wait_resource)-1)) COLLATE Latin1_General_Bin2
+                                    ELSE sp.wait_resource COLLATE Latin1_General_Bin2
+                                END AS resource_description,
                                 sp.wait_time AS wait_duration_ms,
                                 '
                             ELSE

--- a/who_is_active.sql
+++ b/who_is_active.sql
@@ -3082,7 +3082,10 @@ BEGIN;
                                 OR @find_block_leaders = 1
                             ) THEN
                                 'sp.wait_type COLLATE Latin1_General_Bin2 AS wait_type,
-                                sp.wait_resource COLLATE Latin1_General_Bin2 AS resource_description,
+                                CASE
+                                    WHEN CHARINDEX(N''('',sp.wait_resource) > 0 THEN TRIM(LEFT(sp.wait_resource,CHARINDEX(N''('',sp.wait_resource)-1)) COLLATE Latin1_General_Bin2
+                                    ELSE sp.wait_resource COLLATE Latin1_General_Bin2
+                                END AS resource_description,
                                 sp.wait_time AS wait_duration_ms,
                                 '
                             ELSE


### PR DESCRIPTION
Adding handling for additional information that is added to sys.sysprocesses.waitresource when the wait type is Page_Latch in Azure SQL DB. The additional info causes parsing blockers to throw the following error 'Conversion failed when converting the nvarchar value ' 1)' to data type int.'