### PR TITLE
Prevent XML parsing error

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -4372,7 +4372,7 @@ BEGIN;
                             s.query_plan =
                             (
                                 SELECT
-                                    CONVERT(xml, query_plan)
+                                    TRY_CAST(query_plan as xml)
                                 FROM sys.dm_exec_text_query_plan
                                 (
                                     @plan_handle,

--- a/who_is_active.sql
+++ b/who_is_active.sql
@@ -4372,7 +4372,7 @@ BEGIN;
                             s.query_plan =
                             (
                                 SELECT
-                                    CONVERT(xml, query_plan)
+                                    TRY_CAST(query_plan as xml)
                                 FROM sys.dm_exec_text_query_plan
                                 (
                                     @plan_handle,


### PR DESCRIPTION
XML datatype instance has too many levels of nested nodes. Maximum allowed depth is 128 levels.