### PR TITLE
Add automatic line ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # linguist overrides
 *.sql linguist-language=TSQL
+
+# converts to native line endings on checkout for all SQL files
+*.sql text=auto


### PR DESCRIPTION
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings

Internally it's stored as LF, but it converts to the native line endings on checkout. So Windows users will have CRLF, and Linux will have LF