### PR TITLE
Change the DMV we get the status from to sys.dm_exec_sessions instead of sys.sysprocesses.

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -3070,7 +3070,7 @@ BEGIN;
                                 'sp.memory_usage + COALESCE(r.granted_query_memory, 0) AS used_memory,
                                 '
                         END +
-                        'LOWER(sp.status) AS status,
+                        'LOWER(ISNULL(r.status, sp.status)) AS status,
                         COALESCE(r.sql_handle, sp.sql_handle) AS sql_handle,
                         COALESCE(r.statement_start_offset, sp.statement_start_offset) AS statement_start_offset,
                         COALESCE(r.statement_end_offset, sp.statement_end_offset) AS statement_end_offset,


### PR DESCRIPTION
Change the DMV we get the status from to sys.dm_exec_sessions instead of sys.sysprocesses. If ISNULL revert back. This way we can see the sessions running state instead of only runnable status.

Literally changing one line of code on line 3073 from
LOWER(sp.status) AS status,
to
LOWER(ISNULL(r.status, sp.status)) AS status,

I thought I already addressed in PR #77 