### PR TITLE
Fix XML parsing errors from PI delimiter sequences in query text

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -4039,6 +4039,7 @@ BEGIN;
                         s.sql_text =
                         (
                             SELECT
+                                REPLACE(REPLACE(
                                 REPLACE
                                 (
                                     REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
@@ -4072,7 +4073,7 @@ BEGIN;
                                         NCHAR(11),N'?'),NCHAR(8),N'?'),NCHAR(7),N'?'),NCHAR(6),N'?'),NCHAR(5),N'?'),NCHAR(4),N'?'),NCHAR(3),N'?'),NCHAR(2),N'?'),NCHAR(1),N'?'),
                                     NCHAR(0),
                                     N''
-                                ) AS [processing-instruction(query)]
+                                ), N'<?', N'??'), N'?>', N'??') AS [processing-instruction(query)]
                             FOR XML
                                 PATH(''),
                                 TYPE
@@ -4233,7 +4234,7 @@ BEGIN;
                                 CONVERT
                                 (
                                     NVARCHAR(MAX),
-                                    N'--' + NCHAR(13) + NCHAR(10) + br.EventInfo + NCHAR(13) + NCHAR(10) + N'--' COLLATE Latin1_General_Bin2
+                                    N'--' + NCHAR(13) + NCHAR(10) + REPLACE(REPLACE(br.EventInfo, N'<?', N'??'), N'?>', N'??') + NCHAR(13) + NCHAR(10) + N'--' COLLATE Latin1_General_Bin2
                                 ),
                                 NCHAR(31),N'?'),NCHAR(30),N'?'),NCHAR(29),N'?'),NCHAR(28),N'?'),NCHAR(27),N'?'),NCHAR(26),N'?'),NCHAR(25),N'?'),NCHAR(24),N'?'),NCHAR(23),N'?'),NCHAR(22),N'?'),
                                 NCHAR(21),N'?'),NCHAR(20),N'?'),NCHAR(19),N'?'),NCHAR(18),N'?'),NCHAR(17),N'?'),NCHAR(16),N'?'),NCHAR(15),N'?'),NCHAR(14),N'?'),NCHAR(12),N'?'),
@@ -4409,7 +4410,7 @@ BEGIN;
                                         N'-- Could not render showplan due to XML data type limitations. ' + NCHAR(13) + NCHAR(10) +
                                         N'-- To see the graphical plan save the XML below as a .SQLPLAN file and re-open in SSMS.' + NCHAR(13) + NCHAR(10) +
                                         N'--' + NCHAR(13) + NCHAR(10) +
-                                            REPLACE(qp.query_plan, N'<RelOp', NCHAR(13)+NCHAR(10)+N'<RelOp') +
+                                            REPLACE(REPLACE(REPLACE(qp.query_plan, N'<RelOp', NCHAR(13)+NCHAR(10)+N'<RelOp'), N'<?', N'??'), N'?>', N'??') +
                                             NCHAR(13) + NCHAR(10) + N'--' COLLATE Latin1_General_Bin2 AS [processing-instruction(query_plan)]
                                     FROM sys.dm_exec_text_query_plan
                                     (


### PR DESCRIPTION
## Summary

Fixes #99, #128. Escapes XML processing instruction (PI) delimiter sequences `<?` and `?>` in three locations where text is wrapped in `[processing-instruction()]` nodes via `FOR XML PATH`.

- **sql_text** (`est.text` from `sys.dm_exec_sql_text`) — inner query text
- **sql_command** (`br.EventInfo` from `DBCC INPUTBUFFER`) — outer command text  
- **query_plan** fallback (`qp.query_plan` from `sys.dm_exec_text_query_plan`) — text-mode plan for oversized XML plans (error 6335)

## Root Cause

When query text contains the character sequence `?>` (common in XML-related queries, literal strings, or comments), SQL Server's `FOR XML PATH` serialization does **not** escape it inside processing-instruction content. The XML is well-formed in SQL Server's internal binary format — server-side round-trips pass fine — but when serialized to text for the TDS wire protocol, `?>` prematurely terminates the processing instruction per the XML spec.

Any external XML parser (SSMS grid rendering, `sp_xml_preparedocument`, etc.) then fails with:

> *XML parsing: ... Invalid at the top level of the document.*

This is why the error is intermittent — it only occurs when an active session happens to have `?>` in its query text at the moment sp_WhoIsActive runs.

## Fix

`REPLACE(REPLACE(..., N'<?', N'??'), N'?>', N'??')` applied as the outermost transformation at each of the three locations, after the existing control-character REPLACE chain. This converts the PI delimiters to `??` which prevents premature PI boundary detection while preserving the visual intent of the original text.

## Test Plan

- [x] Deployed and tested on SQL Server 2019 and SQL Server 2022
- [x] Confirmed bug reproduces without fix: `sp_xml_preparedocument` fails with "Invalid at the top level of the document" on unescaped PI content
- [x] Confirmed fix works: `?>` escaped to `??` in processing-instruction output, XML parses successfully
- [x] Live end-to-end test: started session executing `SELECT '<?xml version="1.0"?><root/>'`, ran `sp_WhoIsActive @get_outer_command = 1, @get_plans = 1` — completed without error on both servers
- [x] Verified escaped text appears correctly in output: `'??xml version="1.0"??<root/>'`