### PR TITLE
Normalize line endings and strip trailing whitespace

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -449,37 +449,37 @@ BEGIN;
         RAISERROR('Input parameters cannot be NULL', 16, 1);
         RETURN;
     END;
-   
+
     IF @filter_type NOT IN ('session', 'program', 'database', 'login', 'host')
     BEGIN;
         RAISERROR('Valid filter types are: session, program, database, login, host', 16, 1);
         RETURN;
     END;
-   
+
     IF @filter_type = 'session' AND @filter LIKE '%[^0123456789]%'
     BEGIN;
         RAISERROR('Session filters must be valid integers', 16, 1);
         RETURN;
     END;
-   
+
     IF @not_filter_type NOT IN ('session', 'program', 'database', 'login', 'host')
     BEGIN;
         RAISERROR('Valid filter types are: session, program, database, login, host', 16, 1);
         RETURN;
     END;
-   
+
     IF @not_filter_type = 'session' AND @not_filter LIKE '%[^0123456789]%'
     BEGIN;
         RAISERROR('Session filters must be valid integers', 16, 1);
         RETURN;
     END;
-   
+
     IF @show_sleeping_spids NOT IN (0, 1, 2)
     BEGIN;
         RAISERROR('Valid values for @show_sleeping_spids are: 0, 1, or 2', 16, 1);
         RETURN;
     END;
-   
+
     IF @get_plans NOT IN (0, 1, 2)
     BEGIN;
         RAISERROR('Valid values for @get_plans are: 0, 1, or 2', 16, 1);
@@ -717,7 +717,7 @@ BEGIN;
         ORDER BY
             param_group,
             group_order;
-       
+
         WITH
         a0 AS
         (SELECT 1 AS n UNION ALL SELECT 1),
@@ -965,7 +965,7 @@ BEGIN;
             UNION ALL
             SELECT '[physical_io_delta]', 17
             WHERE
-                @delta_interval > 0   
+                @delta_interval > 0
                 AND @get_task_info = 2
             UNION ALL
             SELECT '[reads_delta]', 18
@@ -1101,13 +1101,13 @@ BEGIN;
                 1,
                 ''
             );
-   
+
     IF COALESCE(RTRIM(@output_column_list), '') = ''
     BEGIN;
         RAISERROR('No valid column matches found in @output_column_list or no columns remain due to selected options.', 16, 1);
         RETURN;
     END;
-   
+
     IF @destination_table <> ''
     BEGIN;
         SET @destination_table =
@@ -1117,7 +1117,7 @@ BEGIN;
             COALESCE(QUOTENAME(PARSENAME(@destination_table, 2)) + '.', '') +
             --table
             COALESCE(QUOTENAME(PARSENAME(@destination_table, 1)), '');
-           
+
         IF COALESCE(RTRIM(@destination_table), '') = ''
         BEGIN;
             RAISERROR('Destination table not properly formatted.', 16, 1);
@@ -1371,7 +1371,7 @@ BEGIN;
 
         --Used for the delta pull
         REDO:;
-       
+
         IF
             @get_locks = 1
             AND @recursion = 1
@@ -1796,7 +1796,7 @@ BEGIN;
             CREATE STATISTICS s_principal_name ON #locks (principal_name)
             WITH SAMPLE 0 ROWS, NORECOMPUTE;
         END;
-       
+
         DECLARE
             @sql VARCHAR(MAX),
             @sql_n NVARCHAR(MAX),
@@ -2835,15 +2835,15 @@ BEGIN;
                         (
                             SELECT TOP(@i)
                             (
-                                SELECT TOP(@i)   
+                                SELECT TOP(@i)
                                     x.request_time,
                                     x.grant_time,
                                     x.wait_time_ms,
-                                    x.requested_memory_kb,   
+                                    x.requested_memory_kb,
                                     x.mg_granted_memory_kb AS granted_memory_kb,
                                     x.mg_used_memory_kb AS used_memory_kb,
                                     x.max_used_memory_kb,
-                                    x.ideal_memory_kb,   
+                                    x.ideal_memory_kb,
                                     x.required_memory_kb,
                                     x.queue_id,
                                     x.wait_order,
@@ -2870,7 +2870,7 @@ BEGIN;
                                     TYPE
                             ),
                             (
-                                SELECT TOP(@i)   
+                                SELECT TOP(@i)
                                     x.wg_name AS name,
                                     x.request_max_memory_grant_percent,
                                     x.request_max_cpu_time_sec,
@@ -2881,7 +2881,7 @@ BEGIN;
                                     TYPE
                             ),
                             (
-                                SELECT TOP(@i)   
+                                SELECT TOP(@i)
                                     x.rp_name AS name,
                                     x.min_memory_percent,
                                     x.max_memory_percent,
@@ -2896,7 +2896,7 @@ BEGIN;
                             FOR XML
                                 PATH(''memory_info''),
                                 TYPE
-                        )               
+                        )
                     '
                     ELSE
                         'NULL '
@@ -3778,7 +3778,7 @@ BEGIN;
             open_tran_count,
             sql_handle,
             statement_start_offset,
-            statement_end_offset,       
+            statement_end_offset,
             sql_text,
             plan_handle,
             blocking_session_id,
@@ -3807,7 +3807,7 @@ BEGIN;
                 OR @output_column_list LIKE '%|[tran_log_writes|]%' ESCAPE '|'
                 OR @output_column_list LIKE '%|[implicit_tran|]%' ESCAPE '|'
             )
-        BEGIN;   
+        BEGIN;
             DECLARE @i INT;
             SET @i = 2147483647;
 
@@ -3960,9 +3960,9 @@ BEGIN;
                                         WHERE
                                             s1.transaction_id = s_tran.transaction_id
                                             AND s1.recursion = 1
-                                           
+
                                         UNION ALL
-                                   
+
                                         SELECT TOP(1)
                                             s2.session_id,
                                             s2.request_id
@@ -3994,7 +3994,7 @@ BEGIN;
         END;
 
         --Variables for text and plan collection
-        DECLARE   
+        DECLARE
             @session_id SMALLINT,
             @request_id INT,
             @sql_handle VARBINARY(64),
@@ -4106,9 +4106,9 @@ BEGIN;
                                     text,
                                     0 AS row_num
                                 FROM sys.dm_exec_sql_text(@sql_handle)
-                               
+
                                 UNION ALL
-                               
+
                                 SELECT
                                     NULL,
                                     1 AS row_num
@@ -4836,7 +4836,7 @@ BEGIN;
             WITH SAMPLE 0 ROWS, NORECOMPUTE;
             CREATE STATISTICS s_query_error ON #blocked_requests (query_error)
             WITH SAMPLE 0 ROWS, NORECOMPUTE;
-       
+
             INSERT #blocked_requests
             (
                 session_id,
@@ -4875,20 +4875,20 @@ BEGIN;
                     OR t.hobt_id IS NOT NULL
                     OR t.schema_node IS NOT NULL
                 );
-           
+
             DECLARE blocks_cursor
             CURSOR LOCAL FAST_FORWARD
             FOR
                 SELECT DISTINCT
                     database_name
                 FROM #blocked_requests;
-               
+
             OPEN blocks_cursor;
-           
+
             FETCH NEXT FROM blocks_cursor
             INTO
                 @database_name;
-           
+
             WHILE @@FETCH_STATUS = 0
             BEGIN;
                 BEGIN TRY;
@@ -4931,7 +4931,7 @@ BEGIN;
                             s.schema_id = COALESCE(o.schema_id, b.schema_id)
                         WHERE
                             b.database_name = @database_name; ';
-                   
+
                     EXEC sp_executesql
                         @sql_n,
                         N'@database_name sysname',
@@ -4965,10 +4965,10 @@ BEGIN;
                 INTO
                     @database_name;
             END;
-           
+
             CLOSE blocks_cursor;
             DEALLOCATE blocks_cursor;
-           
+
             UPDATE s
             SET
                 additional_info.modify
@@ -5079,7 +5079,7 @@ BEGIN;
                             s.session_id = @session_id
                             AND s.recursion = 1
                         OPTION (KEEPFIXED PLAN);
-                       
+
                         UPDATE s
                         SET
                             additional_info.modify
@@ -5097,7 +5097,7 @@ BEGIN;
                 BEGIN CATCH;
                     DECLARE @msdb_error_message NVARCHAR(256);
                     SET @msdb_error_message = ERROR_MESSAGE();
-               
+
                     UPDATE s
                     SET
                         additional_info.modify
@@ -5128,7 +5128,7 @@ BEGIN;
                 WHERE
                     s.recursion = 1
             OPTION (KEEPFIXED PLAN);
-           
+
             OPEN agent_cursor;
 
             FETCH NEXT FROM agent_cursor
@@ -5154,7 +5154,7 @@ BEGIN;
             CLOSE agent_cursor;
             DEALLOCATE agent_cursor;
         END;
-       
+
         IF
             @delta_interval > 0
             AND @recursion <> 1


### PR DESCRIPTION
## Summary

Fixes #142. 40 lines in `sp_WhoIsActive.sql` had bare LF line endings (instead of CRLF) with trailing spaces (3-43 characters). The remaining 5,455 lines used CRLF with no trailing whitespace.

This inconsistency causes any editor or tool that normalizes whitespace on save to produce a diff with 40+ phantom changes mixed in with the actual fix, making PRs harder to review. (This affected PR #140 and #141 during development.)

Zero functional changes — `git diff -w` is empty.

## Test Plan

- [x] Verified `git diff -w` produces empty output (no non-whitespace changes)
- [x] Deployed and ran `sp_WhoIsActive` with `@get_memory_info`, `@get_outer_command`, `@get_plans` on SQL Server 2019 and 2022
- [x] Confirmed 0 lines with trailing whitespace and 0 bare LF line endings after fix