### PR TITLE
Fix CPU column ordering on case-sensitive collation instances

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -113,7 +113,7 @@ ALTER PROC dbo.sp_WhoIsActive
     --Each element in this list must be one of the valid output column names. Names must be
     --delimited by square brackets. White space, formatting, and additional characters are
     --allowed, as long as the list contains exact matches of delimited valid column names.
-    @output_column_list VARCHAR(8000) = '[dd%][session_id][sql_text][sql_command][login_name][wait_info][tasks][tran_log%][cpu%][temp%][block%][reads%][writes%][context%][physical%][query_plan][locks][%]',
+    @output_column_list VARCHAR(8000) = '[dd%][session_id][sql_text][sql_command][login_name][wait_info][tasks][tran_log%][CPU%][temp%][block%][reads%][writes%][context%][physical%][query_plan][locks][%]',
 
     --Column(s) by which to sort output, optionally with sort directions.
         --Valid column choices:


### PR DESCRIPTION
## Summary

Fixes #123. Supersedes the open PR #113 (which had whitespace noise from mixed line endings).

The default `@output_column_list` parameter had `[cpu%]` in lowercase, but the actual column name is `[CPU]` (uppercase everywhere else in the proc — lines 946, 1205, 2435-2438). On case-sensitive collation instances, the `LIKE` match at line 2435 fails because `[cpu%]` doesn't match `[CPU]`. This causes the CPU column to be excluded from its expected position, breaking `INSERT INTO` when using a schema generated on a case-insensitive instance.

Three-character fix: `[cpu%]` → `[CPU%]` in the `@output_column_list` default value.

## Version Testing

| Server  | Install | Execute | Status |
|---------|---------|---------|--------|
| SQL2016 | 1/1     | 5/5     | PASS |
| SQL2017 | 1/1     | 5/5     | PASS |
| SQL2019 | 1/1     | 5/5     | PASS |
| SQL2022 | 1/1     | 5/5     | PASS |
| SQL2025 | 1/1     | 5/5     | PASS |

## Test Plan

- [x] Installed on all SQL Server versions (2016-2025)
- [x] Executed with 5 parameter combinations on all versions (25/25 passed)
- [ ] Manual spot-check on a case-sensitive collation instance to verify CPU column position

Generated with [Claude Code](https://claude.com/claude-code)