### PR TITLE
Fix nvarchar conversion errors in lock parsing (#135)

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -1563,9 +1563,8 @@ BEGIN;
                                 ELSE '.' + tl.resource_subtype
                             END AS resource_type,
                         COALESCE(DB_NAME(tl.resource_database_id), N'(null)') AS database_name,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
                                 WHEN tl.resource_type = 'OBJECT' THEN tl.resource_associated_entity_id
                                 WHEN tl.resource_description LIKE '%object_id = %' THEN
@@ -1587,19 +1586,19 @@ BEGIN;
                                     )
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS object_id,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
-                                WHEN tl.resource_type = 'FILE' THEN CONVERT(INT, tl.resource_description)
+                                WHEN tl.resource_type = 'FILE' THEN TRY_CAST(tl.resource_description AS INT)
                                 WHEN tl.resource_type IN ('PAGE', 'EXTENT', 'RID') THEN LEFT(tl.resource_description, CHARINDEX(':', tl.resource_description)-1)
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS file_id,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
                                 WHEN tl.resource_type IN ('PAGE', 'EXTENT', 'RID') THEN
                                     SUBSTRING
@@ -1618,6 +1617,7 @@ BEGIN;
                                     )
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS page_no,
                         CASE
                             WHEN tl.resource_type IN ('PAGE', 'KEY', 'RID', 'HOBT', 'XACT') THEN tl.resource_associated_entity_id
@@ -1627,9 +1627,8 @@ BEGIN;
                             WHEN tl.resource_type = 'ALLOCATION_UNIT' THEN tl.resource_associated_entity_id
                             ELSE NULL
                         END AS allocation_unit_id,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
                                 WHEN
                                     /*TODO: Deal with server principals*/
@@ -1653,10 +1652,10 @@ BEGIN;
                                     )
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS index_id,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
                                 WHEN tl.resource_description LIKE '%schema_id = %' THEN
                                     (
@@ -1677,10 +1676,10 @@ BEGIN;
                                     )
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS schema_id,
-                        CONVERT
+                        TRY_CAST
                         (
-                            INT,
                             CASE
                                 WHEN tl.resource_description LIKE '%principal_id = %' THEN
                                     (
@@ -1701,6 +1700,7 @@ BEGIN;
                                     )
                                 ELSE NULL
                             END
+                            AS INT
                         ) AS principal_id,
                         tl.request_mode,
                         tl.request_status,
@@ -4852,7 +4852,7 @@ BEGIN;
                 database_name,
                 object_id,
                 hobt_id,
-                CONVERT(INT, SUBSTRING(schema_node, CHARINDEX(' = ', schema_node) + 3, LEN(schema_node))) AS schema_id
+                TRY_CAST(SUBSTRING(schema_node, CHARINDEX(' = ', schema_node) + 3, LEN(schema_node)) AS INT) AS schema_id
             FROM
             (
                 SELECT


### PR DESCRIPTION
## Summary
- Replace `CONVERT(INT, ...)` with `TRY_CAST(... AS INT)` at 8 locations in the lock parsing block where `resource_description` strings from `sys.dm_tran_locks` are parsed into integers
- `SUBSTRING`/`CHARINDEX` extraction can produce non-numeric values (spaces, parentheses) from unexpected description formats, causing "Conversion failed when converting the nvarchar value" errors
- `TRY_CAST` returns NULL instead of throwing, gracefully handling malformed inputs
- Uses `TRY_CAST` rather than `TRY_CONVERT` for broader compatibility across database compatibility levels

Fixes #135

## Changed locations
1. `object_id` parsing (line ~1563)
2. `file_id` outer conversion (line ~1588)
3. `file_id` inner conversion for FILE resource type (line ~1592)
4. `page_no` parsing (line ~1597)
5. `index_id` parsing (line ~1627)
6. `schema_id` parsing (line ~1654)
7. `principal_id` parsing (line ~1678)
8. `schema_node` parsing (line ~4849)

## Version Testing
| Server  | Install | Execute |
|---------|---------|---------|
| SQL2016 | OK      | OK      |
| SQL2017 | OK      | OK      |
| SQL2019 | OK      | OK      |
| SQL2022 | OK      | OK      |
| SQL2025 | OK      | OK      |

Tested with `@get_locks = 1` on all versions.

## Test Plan
- [x] Installed on all SQL Server versions (2016-2025)
- [x] Executed with `@get_locks = 1` on all SQL Server versions (2016-2025)
- [ ] Manual spot-check with sessions holding various lock types

Generated with [Claude Code](https://claude.com/claude-code)