### PR TITLE
[#122] Support XACT lock resource type for Optimized Locking

### DIFF
--- a/sp_WhoIsActive.sql
+++ b/sp_WhoIsActive.sql
@@ -1617,7 +1617,7 @@ BEGIN;
                             END
                         ) AS page_no,
                         CASE
-                            WHEN tl.resource_type IN ('PAGE', 'KEY', 'RID', 'HOBT') THEN tl.resource_associated_entity_id
+                            WHEN tl.resource_type IN ('PAGE', 'KEY', 'RID', 'HOBT', 'XACT') THEN tl.resource_associated_entity_id
                             ELSE NULL
                         END AS hobt_id,
                         CASE


### PR DESCRIPTION
## Summary

SQL Server 2025 introduces [Optimized Locking](https://learn.microsoft.com/en-us/sql/relational-databases/performance/optimized-locking), which replaces traditional row/page locks with XACT (transaction) locks. When `@get_locks = 1`, sp_WhoIsActive resolves lock resource types to object names by mapping `resource_associated_entity_id` to a HoBt ID. However, the XACT resource type was not included in this mapping, causing XACT locks to display `(null)` for the object name.

**The fix**: Add `'XACT'` to the existing `IN` list at line 1620 so that XACT waiter locks resolve their `resource_associated_entity_id` (which contains the underlying HoBt ID) to the correct table/index name.

### Before (XACT lock shows null object name)
```xml
<Object name="(null)">
  <Locks>
    <Lock resource_type="XACT" resource_description="[XACT: 5:66385649:0] KEY(8194443284a0)" 
          request_mode="S" request_status="WAIT" request_count="1"/>
  </Locks>
</Object>
```

### After (XACT lock resolves to table and index)
```xml
<Object name="Users" schema_name="dbo">
  <Locks>
    <Lock resource_type="XACT" index_name="PK_Users_Id" 
          request_mode="S" request_status="WAIT" request_count="1"/>
  </Locks>
</Object>
```

## Test plan

- [x] Enabled Optimized Locking on sql2025 StackOverflow2013 database
- [x] Created blocking scenario (two competing UPDATEs on dbo.Users) 
- [x] Verified XACT waiter lock resolves to `Users` table with `PK_Users_Id` index
- [x] Verified `wait_info` correctly shows `LCK_M_S_XACT_MODIFY` wait type
- [x] Deployed and executed on sql2016, sql2017, sql2019, sql2022, sql2025 — no regressions
- [x] Note: XACT lock **owner** correctly shows `(null)` since owner's `resource_associated_entity_id = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)